### PR TITLE
Use ruby 2.7.5 for the linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           command: bundle -v
   linter:
     docker:
-      - image: 'cimg/ruby:2.7-node'
+      - image: 'cimg/ruby:2.7.5'
     steps:
       - checkout
       - ruby/install-deps


### PR DESCRIPTION
By being more strict in the version.
We don't need node for the linter.