### PR TITLE
Fix #33 - Get rid of "Cannot render console from..." by removing web console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ end
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'web-console', '>= 3.3.0'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,6 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.0.0.2)
       execjs
-    bindex (0.8.1)
     bootsnap (1.4.8)
       msgpack (~> 1.0)
     bootstrap (4.3.1)
@@ -316,11 +315,6 @@ GEM
       unf_ext
     unf_ext (0.0.8.1)
     unicode-display_width (2.1.0)
-    web-console (4.0.4)
-      actionview (>= 6.0.0)
-      activemodel (>= 6.0.0)
-      bindex (>= 0.4.0)
-      railties (>= 6.0.0)
     webdrivers (5.0.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -360,7 +354,6 @@ DEPENDENCIES
   selenium-webdriver
   turbolinks (~> 5)
   tzinfo-data
-  web-console (>= 3.3.0)
   webdrivers
   webpacker (~> 4.0)
 


### PR DESCRIPTION
Almost 7 years using `Rails`, never use `console` not even once.