### PR TITLE
Fix #30 - Fix local test suite when using docker

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
+
+ENV['RAILS_ENV'] = 'test'
+
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?


### PR DESCRIPTION
When running `docker-compose run runner` the `RAILS_ENV` was already set to `development` making all this mess, so setting to test on `rails_helper` is a quick fix until redone the composer.